### PR TITLE
Refs #53 - Using 'tar.gz' as default archive format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@ New feature (tar.gz archives) and marketing (talks).
 - Feature #4 - Added support of "accept" header for POST requests on
   directories: accepted types are ZIP (``application/zip``) and TAR.GZ
   (``application/gzip``).
+- Feature #53 - GZIP is now the default archive format when rendering
+  directories. Use "diecutter.default_archive_type = application/zip" in
+  configuration file if you need ZIP format as a default.
 - Refactoring #20 - Render functions return generator ; moved response
   composition (file/archive) into views via writers.
 - Feature #46 - Added content of talks in documentation: AFPY event and

--- a/demo/README
+++ b/demo/README
@@ -159,25 +159,26 @@ GET lists the templates it contains:
 Every template in a directory can be handled as a single file. But let's focus
 on the directory feature...
 
-POST returns an archive, with ZIP format by default:
+POST returns an archive, with TAR.GZ format by default:
 
 .. doctest::
 
-   >>> from StringIO import StringIO
-   >>> from zipfile import ZipFile
+   >>> django_project_url = diecutter_url + '+django_project+'
 
+   >>> from StringIO import StringIO
+   >>> import tarfile
    >>> response = requests.post(django_project_url,
    ...                          {'django_project': u'demo'})
-   >>> print response.headers['Content-Type']
-   application/zip; charset=UTF-8
-   >>> zip_file = ZipFile(StringIO(response.content))
-   >>> print '\n'.join(zip_file.namelist())
+   >>> response.headers['Content-Type']
+   'application/gzip; charset=UTF-8'
+   >>> archive = tarfile.open(fileobj=StringIO(response.content), mode='r|gz')
+   >>> print '\n'.join(archive.getnames())
    demo/manage.py
    demo/demo/__init__.py
    demo/demo/settings.py
    demo/demo/urls.py
    demo/demo/wsgi.py
-   >>> zip_file.close()
+   >>> archive.close()
 
 Without trailing slash, directory name is used as a prefix for filenames.
 Let's try the same requests with a trailing slash:
@@ -196,36 +197,33 @@ Let's try the same requests with a trailing slash:
 
    >>> response = requests.post(django_project_url,
    ...                          {'django_project': u'demo'})
-   >>> zip_file = ZipFile(StringIO(response.content))
-   >>> print '\n'.join(zip_file.namelist())
+   >>> archive = tarfile.open(fileobj=StringIO(response.content), mode='r|gz')
+   >>> print '\n'.join(archive.getnames())
    manage.py
    demo/__init__.py
    demo/settings.py
    demo/urls.py
    demo/wsgi.py
-   >>> zip_file.close()
+   >>> archive.close()
 
-You can get the content as a tar.gz archive instead with the "accept" header:
+You can get the content as a ZIP archive instead with the "accept" header:
 
 .. doctest::
 
-   >>> import tarfile
+   >>> from zipfile import ZipFile
    >>> response = requests.post(django_project_url,
    ...                          {'django_project': u'demo'},
-   ...                          headers={'accept': 'application/gzip'})
-   >>> response.headers['Content-Type']
-   'application/gzip; charset=UTF-8'
-   >>> response_file = StringIO(response.content)
-   >>> try:
-   ...     archive = tarfile.open(fileobj=response_file, mode='r|gz')
-   ...     print '\n'.join(archive.getnames())
-   ... finally:
-   ...     archive.close()
+   ...                          headers={'accept': 'application/zip'})
+   >>> print response.headers['Content-Type']
+   application/zip; charset=UTF-8
+   >>> archive = ZipFile(StringIO(response.content))
+   >>> print '\n'.join(archive.namelist())
    manage.py
    demo/__init__.py
    demo/settings.py
    demo/urls.py
    demo/wsgi.py
+   >>> archive.close()
 
 .. tip::
 
@@ -327,15 +325,15 @@ resource:
    >>> response = requests.post(dynamic_tree_url,
    ...                          {'name': u'Remy',
    ...                           'greeting_list': [u'bonjour', u'bonsoir']})
-   >>> zip_file = ZipFile(StringIO(response.content))
-   >>> print '\n'.join(zip_file.namelist())
+   >>> archive = tarfile.open(fileobj=StringIO(response.content), mode='r:gz')
+   >>> print '\n'.join(archive.getnames())
    bonjour.txt
    bonsoir.txt
-   >>> print zip_file.read('bonjour.txt')
+   >>> print archive.extractfile('bonjour.txt').read()
    bonjour Remy!
-   >>> print zip_file.read('bonsoir.txt')
+   >>> print archive.extractfile('bonsoir.txt').read()
    bonsoir Remy!
-   >>> zip_file.close()
+   >>> archive.close()
 
 Here, the :file:`greeter.txt` template has been rendered several times, with
 different context data.

--- a/demo/templates/diecutter.ini
+++ b/demo/templates/diecutter.ini
@@ -8,6 +8,8 @@ diecutter.token = {{ token|default('') }}
 # Set this to true (without quotes) if you want templates to be readonly,
 # i.e. forbid PUT requests.
 diecutter.readonly = {{ readonly|default('false') }}
+# Default archive format returned when rendering directories.
+diecutter.default_archive_format = {{ default_archive_format|default('application/gzip') }}
 
 pyramid.reload_templates = true
 pyramid.debug_authorization = false

--- a/diecutter/views.py
+++ b/diecutter/views.py
@@ -155,7 +155,16 @@ def get_writers(request, resource, context):
         # Aliases.
         mime_type_map['application/x-gzip'] = mime_type_map['application/gzip']
         # Fallback.
-        mime_type_map['*/*'] = mime_type_map['application/zip']
+        settings = request.registry.settings
+        try:
+            default_type = settings['diecutter.default_archive_type']
+        except KeyError:
+            default_type = 'application/gzip'
+        if default_type not in mime_type_map.keys():
+            raise ConfigurationError(
+                'Cannot use "%s" as "default_archive_type". Supported types '
+                'are: %s' % (default_type, ','.join(mime_type_map.keys())))
+        mime_type_map['*/*'] = mime_type_map[default_type]
         for accepted_mime_type in accepted_mime_types:
             try:
                 return mime_type_map[accepted_mime_type]

--- a/docs/client/directories.txt
+++ b/docs/client/directories.txt
@@ -67,18 +67,18 @@ POST renders directory against a context:
 
 .. code-block:: text
 
-   $ curl -X POST -d name="world" http://localhost:8106/greetings > greetings.zip
-   $ unzip greetings.zip
+   $ curl -X POST -d name="world" -s http://localhost:8106/greetings | tar -zx
+
    $ tree greetings
    greetings
    ├── hello.txt
    └── goodbye.txt
-
    0 directory, 2 files
 
-   $ cat hello.txt
+   $ cat greetings/hello.txt
    Hello world!
-   $ cat goodbye.txt
+
+   $ cat greetings/goodbye.txt
    Goodbye world!
 
 All files in directory are rendered with the same context data.
@@ -89,18 +89,19 @@ filenames are prefixed with directory name.
 Supported archives types: "accept" header
 =========================================
 
-By default, POST requests return ZIP archives.
+By default, POST requests return GZIP archives.
 
-You can get the content as a tar.gz archive with the "accept" header:
+You can get the content as a TAR.GZ archive with the "accept" header:
 
 .. code:: text
 
-   $ curl -s -X POST --header "accept:application/gzip" -d django_project=demo http://localhost:8106/+django_project+/ | tar -zt
-   manage.py
-   demo/__init__.py
-   demo/settings.py
-   demo/urls.py
-   demo/wsgi.py 
+   $ curl -X POST --header "accept:application/zip" -d name="world" http://localhost:8106/greetings > greetings.zip
+   $ unzip greetings.zip
+   $ tree greetings
+   greetings
+   ├── hello.txt
+   └── goodbye.txt
+   0 directory, 2 files
 
 .. tip::
 
@@ -109,7 +110,7 @@ You can get the content as a tar.gz archive with the "accept" header:
 
    .. code:: text
 
-      $ curl -X POST --header "accept:fake/mime-type" -d django_project=demo http://localhost:8106/+django_project+/
+      $ curl -X POST --header "accept:fake/mime-type" -d name="world" http://localhost:8106/greetings
       406 Not Acceptable
 
       The server could not comply with the request since it is either malformed or

--- a/docs/client/dynamic-trees.txt
+++ b/docs/client/dynamic-trees.txt
@@ -99,16 +99,15 @@ Now let's render the directory as an archive:
    $ curl -X POST \
           -d name=Remy -d greetings=hello -d greetings=goodbye \
           http://localhost:8106/dynamic-greetings \
-          > dynamic-greetings.zip
-   $ unzip dynamic-greetings.zip
+          | tar -zxv
    $ tree dynamic-greetings
    dynamic-greetings
    ├── hello.txt
    └── goodbye.txt
-    
    0 directory, 2 files
 
    $ cat hello.txt
    hello Remy!
+
    $ cat goodbye.txt
    goodbye Remy!

--- a/docs/client/output-filenames.txt
+++ b/docs/client/output-filenames.txt
@@ -20,13 +20,8 @@ The variables within ``+`` will be resolved and replaced by their value:
 
 .. code-block:: text
 
-   $ curl -X POST -d bar=baz http://localhost:8106/foo > foo.zip
-   $ unzip foo.zip
-   $ tree foo
-   foo
-   └── baz.txt
-
-   0 directories, 1 file
+   $ curl -X POST -d bar=baz http://localhost:8106/foo | tar -zt
+   foo/baz.txt
 
 .. note::
 


### PR DESCRIPTION
Added 'diecutter.default_archive_type' configuration directive, so that you can set "application/zip" as a default (backward compatibility).
