### PR TITLE
Removed badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,6 @@
 diecutter
 #########
 
-.. raw:: html
-
-   <a alt="Build status" href="http://badge.fury.io/py/diecutter"><img src="https://badge.fury.io/py/diecutter.png"></a>
-   <a href="https://travis-ci.org/diecutter/diecutter"><img src="https://travis-ci.org/diecutter/diecutter.png?branch=master"></a>
-   <a href="https://pypi.python.org/pypi/diecutter"><img src="https://pypip.in/d/diecutter/badge.png"></a>
-
 Templates as a service.
 
 ``diecutter`` exposes an API where you manage templates as resources.


### PR DESCRIPTION
Refs #103 
PyPI can render README as HTML, and Sphinx does not complain about remote images.
